### PR TITLE
Fix race conditions where LibLinear's output is read before it's fully written

### DIFF
--- a/src/main/java/com/digitalpebble/classification/liblinear/LibLinearApplier.java
+++ b/src/main/java/com/digitalpebble/classification/liblinear/LibLinearApplier.java
@@ -97,6 +97,10 @@ public class LibLinearApplier extends TextClassifier {
 				.toArray(new String[commandList.size()]);
 		
 		process = Runtime.getRuntime().exec(commandArray);
+		
+		int value = process.waitFor();
+		if (value != 0)
+			throw new IOException("Process unsuccessful");
 		// Read labels from output file
 		BufferedReader in = new BufferedReader(new FileReader(output));
 		String line = null;
@@ -109,10 +113,6 @@ public class LibLinearApplier extends TextClassifier {
 			docNum++;
 		}
 		in.close();
-		
-		int value = process.waitFor();
-		if (value != 0)
-			throw new IOException("Process unsuccessful");
 	}
 
 	private String getParameters() {

--- a/src/main/java/com/digitalpebble/classification/liblinear/LibLinearModelCreator.java
+++ b/src/main/java/com/digitalpebble/classification/liblinear/LibLinearModelCreator.java
@@ -89,14 +89,14 @@ public class LibLinearModelCreator extends Learner {
 		String[] commandArray = (String[]) commandList
 				.toArray(new String[commandList.size()]);
 		process = Runtime.getRuntime().exec(commandArray);
+		int value = process.waitFor();
+		if (value != 0)
+			throw new IOException("Process unsuccessful");
 		// Read output:
 		BufferedReader in = new BufferedReader(new InputStreamReader(process
 				.getInputStream()));
 		this.outputLearner = Utils.readOutput(in);
 		in.close();
-		int value = process.waitFor();
-		if (value != 0)
-			throw new IOException("Process unsuccessful");
 	}
 
 	protected boolean supportsMultiLabels() {


### PR DESCRIPTION
In both training and inference, it's important to wait for LibLinear to finish writing its output before we try to read it. The code did wait for LibLinear to quit, but it tried to read the output earlier, causing a race condition.